### PR TITLE
chore(renovate): enable fork processing

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>statnett/renovate-config"],
+  "forkProcessing": "enabled",
 }


### PR DESCRIPTION
As long as this is a fork, you need to enable [fork processing](https://docs.renovatebot.com/configuration-options/#forkprocessing) if you want Renovate updates (it is some exceptions, ref the `auto` mode, but it seems like those are not in place here). 